### PR TITLE
[CI] [TESTNET ONE] continue testnet daemon code

### DIFF
--- a/bin/test/one/src/daemon/main.rs
+++ b/bin/test/one/src/daemon/main.rs
@@ -41,11 +41,14 @@ extern crate log;
 extern crate simple_logger;
 
 fn database_present() -> bool {
-    let get_res =  getData(config().db_path + &"/chainsindex".to_owned(), "digest".to_string());
+    let get_res = getData(
+        config().db_path + &"/chainsindex".to_owned(),
+        "digest".to_string(),
+    );
     if get_res == "-1".to_owned() {
         return false;
     } else if get_res == "0".to_string() {
-        return false
+        return false;
     } else {
         return true;
     }


### PR DESCRIPTION
```
error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:256:33
    |
256 |                     amount: rng.gen(),
    |                                 ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:261:48
    |
261 |                         "rc".to_owned() + &rng.gen::<u64>().to_string(),
    |                                                ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:264:36
    |
264 |                     gas_price: rng.gen::<u16>() as u64,
    |                                    ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:265:34
    |
265 |                     max_gas: rng.gen::<u16>() as u64,
    |                                  ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:266:30
    |
266 |                     gas: rng.gen::<u16>() as u64,
    |                              ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error[E0599]: no method named `gen` found for struct `rand::prelude::ThreadRng` in the current scope
   --> blockchain/src/lib.rs:267:32
    |
267 |                     nonce: rng.gen(),
    |                                ^^^ method not found in `rand::prelude::ThreadRng`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::rand::Rng;`

error: aborting due to 6 previous errors

For more information about this error, try `rustc --explain E0599`.
error: could not compile `avrio_blockchain`.
```

```
error[E0308]: mismatched types
   --> p2p/src/lib.rs:101:15
    |
101 |     return Ok(()); // TODO: send block to all peers and await a response, return Ok(number of peers who responded)
    |               ^^ expected `u64`, found `()`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `avrio_p2p`.
```