### PR TITLE
Fixed all Rust compiler warnings

### DIFF
--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -2,21 +2,19 @@
 
 extern crate avrio_config;
 use avrio_config::config;
-use avrio_database::getData;
 
 extern crate hex;
 use crate::{Block, Header};
 use avrio_core::transaction::Transaction;
 
 #[derive(Debug, PartialEq)]
-pub enum genesisBlockErrors {
+pub enum GenesisBlockErrors {
     BlockNotFound,
     OtherDb,
     Other,
 }
 
 extern crate avrio_crypto;
-use avrio_crypto::Wallet;
 
 pub fn genesis_blocks() -> Vec<Block> {
     /*example
@@ -86,14 +84,14 @@ pub fn get_genesis_txns() -> Vec<Transaction> {
     ];
 }
 
-pub fn generateGenesisBlock(
-    chainKey: String,
-    privKey: String,
-) -> Result<Block, genesisBlockErrors> {
+pub fn generate_genesis_block(
+    chain_key: String,
+    priv_key: String,
+) -> Result<Block, GenesisBlockErrors> {
     let mut my_genesis_txns: Vec<Transaction> = vec![];
     let genesis_txns = get_genesis_txns();
     for tx in genesis_txns {
-        if tx.receive_key == chainKey {
+        if tx.receive_key == chain_key {
             my_genesis_txns.push(tx);
         }
     }
@@ -103,7 +101,7 @@ pub fn generateGenesisBlock(
             version_major: 0,
             version_breaking: 0,
             version_minor: 1,
-            chain_key: chainKey,
+            chain_key: chain_key,
             prev_hash: "00000000000".to_owned(),
             height: 0,
             timestamp: 0,
@@ -117,15 +115,15 @@ pub fn generateGenesisBlock(
     };
 
     genesis_block.hash();
-    genesis_block.sign(&privKey);
+    genesis_block.sign(&priv_key).unwrap();
     return Ok(genesis_block);
 }
 /// Reads the genesis block for this chain from the list of blocks
-pub fn getGenesisBlock(chainkey: &String) -> Result<Block, genesisBlockErrors> {
+pub fn get_genesis_block(chainkey: &String) -> Result<Block, GenesisBlockErrors> {
     for block in genesis_blocks() {
         if block.header.chain_key == *chainkey {
             return Ok(block);
         }
     }
-    return Err(genesisBlockErrors::BlockNotFound);
+    return Err(GenesisBlockErrors::BlockNotFound);
 }

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate avrio_config;
 extern crate avrio_core;
 extern crate avrio_database;
-use crate::genesis::{genesisBlockErrors, getGenesisBlock};
+use crate::genesis::{get_genesis_block, GenesisBlockErrors};
 use avrio_config::config;
 use avrio_core::{
-    account::{getAccount, setAccount, Account},
+    account::{get_account, set_account, Account},
     transaction::*,
 };
 use avrio_database::*;
@@ -14,11 +14,7 @@ extern crate log;
 
 extern crate bs58;
 
-use ring::{
-    digest::SHA256,
-    rand as randc,
-    signature::{self, KeyPair},
-};
+use ring::signature;
 extern crate rand;
 
 use avrio_crypto::Hashable;
@@ -27,20 +23,20 @@ use std::fs::File;
 use std::io::prelude::*;
 
 #[derive(Debug)]
-pub enum blockValidationErrors {
-    invalidBlockhash,
-    badSignature,
-    indexMissmatch,
-    invalidPreviousBlockhash,
-    invalidTransaction(TransactionValidationErrors),
-    genesisBlockMissmatch,
-    failedToGetGenesisBlock,
-    blockExists,
-    tooLittleSignatures,
-    badNodeSignature,
-    timestampInvalid,
-    networkMissmatch,
-    other,
+pub enum BlockValidationErrors {
+    InvalidBlockhash,
+    BadSignature,
+    IndexMissmatch,
+    InvalidPreviousBlockhash,
+    InvalidTransaction(TransactionValidationErrors),
+    GenesisBlockMissmatch,
+    FailedToGetGenesisBlock,
+    BlockExists,
+    TooLittleSignatures,
+    BadNodeSignature,
+    TimestampInvalid,
+    NetworkMissmatch,
+    Other,
 }
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -96,7 +92,7 @@ impl Hashable for BlockSignature {
 impl BlockSignature {
     pub fn enact(&self) -> std::result::Result<(), Box<dyn std::error::Error>> {
         // we are presuming the vote is valid - if it is not this is going to mess stuff up!
-        if saveData(
+        if save_data(
             self.nonce.to_string(),
             config().db_path + "/fn-certificates",
             self.signer_public_key.clone(),
@@ -108,7 +104,7 @@ impl BlockSignature {
         }
     }
     pub fn valid(&self) -> bool {
-        if &getData(
+        if &get_data(
             config().db_path + "/fn-certificates",
             &self.signer_public_key,
         ) == "-1"
@@ -116,18 +112,18 @@ impl BlockSignature {
             return false;
         } else if self.hash != self.hash_return() {
             return false;
-        } else if getData(
+        } else if get_data(
             config().db_path + "/chains/" + &self.signer_public_key + "-chainindex",
             "sigcount",
         ) != self.nonce.to_string()
         {
             return false;
-        } else if self.timestamp - (config().transactionTimestampMaxOffset as u64)
+        } else if self.timestamp - (config().transaction_timestamp_max_offset as u64)
             < (SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("Time went backwards")
                 .as_millis() as u64)
-            || self.timestamp + (config().transactionTimestampMaxOffset as u64)
+            || self.timestamp + (config().transaction_timestamp_max_offset as u64)
                 < (SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("Time went backwards")
@@ -208,16 +204,15 @@ impl BlockSignature {
 
 pub fn generate_merkle_root_all() -> std::result::Result<String, Box<dyn std::error::Error>> {
     trace!(target: "blockchain::chain_digest","Generating merkle root from scratch");
-    let mut roots: Vec<String> = vec![];
-    if let Ok(db) = openDb(config().db_path + "/chainlist") {
+    if let Ok(db) = open_db(config().db_path + "/chainlist") {
         let mut iter = db.raw_iterator();
         iter.seek_to_first();
-        let cd_db = openDb(config().db_path + &"/chaindigest".to_owned()).unwrap();
+        let cd_db = open_db(config().db_path + &"/chaindigest".to_owned()).unwrap();
         while iter.valid() {
             if let Some(chain) = iter.key() {
                 if let Ok(chain_string) = String::from_utf8(chain.to_vec()) {
                     if let Ok(blkdb) =
-                        openDb(config().db_path + "/chains/" + &chain_string + "-chainindex")
+                        open_db(config().db_path + "/chains/" + &chain_string + "-chainindex")
                     {
                         let mut blkiter = blkdb.raw_iterator();
                         blkiter.seek_to_first();
@@ -239,12 +234,12 @@ pub fn generate_merkle_root_all() -> std::result::Result<String, Box<dyn std::er
             iter.next();
         }
     }
-    return Ok(getData(config().db_path + &"/chainsdigest", "master"));
+    return Ok(get_data(config().db_path + &"/chainsdigest", "master"));
 }
 
 pub fn update_chain_digest(new_blk_hash: &String, cd_db: &rocksdb::DB) -> String {
     trace!(target: "blockchain::chain_digest","Updating chain digest with block hash: {}", new_blk_hash);
-    let curr = getDataDb(cd_db, "master");
+    let curr = get_data_db(cd_db, "master");
     let root: String;
     if &curr == "-1" {
         trace!(target: "blockchain::chain_digest","chain digest not set");
@@ -253,15 +248,15 @@ pub fn update_chain_digest(new_blk_hash: &String, cd_db: &rocksdb::DB) -> String
         trace!(target: "blockchain::chain_digest","Updating set chain digest. Curr: {}", curr);
         root = avrio_crypto::raw_lyra(&(curr + new_blk_hash));
     }
-    let _ = setDataDb(&root, &cd_db, &"master");
+    let _ = set_data_db(&root, &cd_db, &"master");
     trace!(target: "blockchain::chain_digest","Set chain digest to: {}.", root);
     drop(cd_db);
     return root;
 }
 
 /// returns the block when you know the chain and the height
-pub fn getBlock(chainkey: &String, height: u64) -> Block {
-    let hash = getData(
+pub fn get_block(chainkey: &String, height: u64) -> Block {
+    let hash = get_data(
         config().db_path + "/chains/" + chainkey + "-chainindex",
         &height.to_string(),
     );
@@ -270,16 +265,16 @@ pub fn getBlock(chainkey: &String, height: u64) -> Block {
     } else if hash == "0".to_owned() {
         return Block::default();
     } else {
-        return getBlockFromRaw(hash);
+        return get_block_from_raw(hash);
     }
 }
 
 /// returns the block when you only know the hash by opeining the raw blk-HASH.dat file (where hash == the block hash)
-pub fn getBlockFromRaw(hash: String) -> Block {
+pub fn get_block_from_raw(hash: String) -> Block {
     if let Ok(mut file) = File::open(config().db_path + &"/blocks/blk-".to_owned() + &hash + ".dat")
     {
         let mut contents = String::new();
-        file.read_to_string(&mut contents);
+        file.read_to_string(&mut contents).unwrap();
         return serde_json::from_str(&contents).unwrap_or_default();
     } else {
         return Block::default();
@@ -287,7 +282,7 @@ pub fn getBlockFromRaw(hash: String) -> Block {
 }
 
 /// formats the block into a .dat file and saves it under block-hash.dat
-pub fn saveBlock(block: Block) -> std::result::Result<(), Box<dyn std::error::Error>> {
+pub fn save_block(block: Block) -> std::result::Result<(), Box<dyn std::error::Error>> {
     trace!("Saving block with hash: {}", block.hash);
     let encoded: Vec<u8> = serde_json::to_string(&block)?.as_bytes().to_vec();
     let mut file = File::create(config().db_path + "/blocks/blk-" + &block.hash + ".dat")?;
@@ -351,7 +346,7 @@ impl Block {
         return Ok(());
     }
     /// Returns true if signature on block is valid
-    pub fn validSignature(&self) -> bool {
+    pub fn valid_signature(&self) -> bool {
         let msg: &[u8] = self.hash.as_bytes();
         let peer_public_key = signature::UnparsedPublicKey::new(
             &signature::ED25519,
@@ -385,53 +380,54 @@ impl Block {
             });
         return res;
     }
-    pub fn isOtherBlock(&self, OtherBlock: &Block) -> bool {
-        self == OtherBlock
+    pub fn is_other_block(&self, other_block: &Block) -> bool {
+        self == other_block
     }
 }
 // TODO: finish enact block
 /// Enacts a block. Updates all relavant dbs and files
 pub fn enact_block(block: Block) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let chaindex_db = openDb(
+    let chaindex_db = open_db(
         config().db_path
             + &"/chains/".to_owned()
             + &block.header.chain_key
             + &"-chainindex".to_owned(),
     )
     .unwrap();
-    if getDataDb(&chaindex_db, &block.header.height.to_string()) == "-1" {
+    if get_data_db(&chaindex_db, &block.header.height.to_string()) == "-1" {
         debug!("block not in invs");
         let hash = block.hash.clone();
         use std::sync::Arc;
-        let arc_db = Arc::new(openDb(config().db_path + &"/chaindigest".to_owned()).unwrap());
+        let arc_db = Arc::new(open_db(config().db_path + &"/chaindigest".to_owned()).unwrap());
         let arc = arc_db.clone();
         std::thread::spawn(move || {
             update_chain_digest(&hash, &arc);
         });
-        setDataDb(&block.hash, &chaindex_db, &"topblockhash");
-        setDataDb(
+        set_data_db(&block.hash, &chaindex_db, &"topblockhash");
+        set_data_db(
             &(block.header.height + 1).to_string(),
             &chaindex_db,
             &"blockcount",
         );
         trace!("set top block hash for sender");
-        let inv_sender_res = setDataDb(&block.hash, &chaindex_db, &block.header.height.to_string());
+        let inv_sender_res =
+            set_data_db(&block.hash, &chaindex_db, &block.header.height.to_string());
         trace!("Saved inv for sender: {}", block.header.chain_key);
         if inv_sender_res != 1 {
             return Err("failed to save sender inv".into());
         }
-        let block_count = getDataDb(&arc_db, &"blockcount");
+        let block_count = get_data_db(&arc_db, &"blockcount");
         if block_count == "-1".to_owned() {
-            setDataDb(&"1".to_owned(), &arc_db, &"blockcount");
+            set_data_db(&"1".to_owned(), &arc_db, &"blockcount");
             trace!("set block count, prev: -1 (not set), new: 1");
         } else {
             let mut bc: u64 = block_count.parse().unwrap_or_default();
             bc += 1;
-            setDataDb(&bc.to_string(), &arc_db, &"blockcount");
+            set_data_db(&bc.to_string(), &arc_db, &"blockcount");
             trace!("Updated non-zero block count, new count: {}", bc);
         }
         if block.header.height == 0 {
-            if saveData(
+            if save_data(
                 "".to_owned(),
                 config().db_path + "/chainlist",
                 block.header.chain_key.clone(),
@@ -440,25 +436,25 @@ pub fn enact_block(block: Block) -> std::result::Result<(), Box<dyn std::error::
                 return Err("failed to add chain to chainslist".into());
             } else {
                 let newacc = Account::new(block.header.chain_key.clone());
-                if setAccount(&newacc) != 1 {
+                if set_account(&newacc) != 1 {
                     return Err("failed to save new account".into());
                 }
             }
-            if avrio_database::getDataDb(&chaindex_db, &"txncount") == "-1".to_owned() {
-                avrio_database::setDataDb(&"0".to_string(), &chaindex_db, &"txncount");
+            if avrio_database::get_data_db(&chaindex_db, &"txncount") == "-1".to_owned() {
+                avrio_database::set_data_db(&"0".to_string(), &chaindex_db, &"txncount");
             }
         }
-        let txn_db = openDb(config().db_path + &"/transactions".to_owned()).unwrap();
+        let txn_db = open_db(config().db_path + &"/transactions".to_owned()).unwrap();
         for txn in block.txns {
             trace!("enacting txn with hash: {}", txn.hash);
             txn.enact(&chaindex_db)?;
             trace!("Enacted txn. Saving txn to txindex db (db_name  = transactions)");
-            if setDataDb(&block.hash, &txn_db, &txn.hash) != 1 {
+            if set_data_db(&block.hash, &txn_db, &txn.hash) != 1 {
                 return Err("failed to save txn in transactions db".into());
             }
             trace!("Saving invs");
             if txn.sender_key != txn.receive_key && txn.sender_key != block.header.chain_key {
-                let rec_db = openDb(
+                let rec_db = open_db(
                     config().db_path
                         + &"/chains/".to_owned()
                         + &txn.receive_key
@@ -466,23 +462,23 @@ pub fn enact_block(block: Block) -> std::result::Result<(), Box<dyn std::error::
                 )
                 .unwrap();
                 let inv_receiver_res =
-                    setDataDb(&block.hash, &rec_db, &block.header.height.to_string());
+                    set_data_db(&block.hash, &rec_db, &block.header.height.to_string());
                 if inv_receiver_res != 1 {
                     return Err("failed to save reciver inv".into());
                 }
-                let curr_block_count: String = getDataDb(&rec_db, &"blockcount");
+                let curr_block_count: String = get_data_db(&rec_db, &"blockcount");
                 if curr_block_count == "-1" {
-                    setDataDb(&"0".to_owned(), &rec_db, &"blockcount");
+                    set_data_db(&"0".to_owned(), &rec_db, &"blockcount");
                 } else {
                     let curr_block_count_val: u64 = curr_block_count.parse().unwrap_or_default();
-                    setDataDb(
+                    set_data_db(
                         &(curr_block_count_val + 1).to_string(),
                         &rec_db,
                         &"blockcount",
                     );
                 }
 
-                setDataDb(&block.hash, &rec_db, &"topblockhash");
+                set_data_db(&block.hash, &rec_db, &"topblockhash");
                 trace!("set top block hash for reciever");
                 drop(rec_db);
             }
@@ -496,17 +492,17 @@ pub fn enact_block(block: Block) -> std::result::Result<(), Box<dyn std::error::
 }
 
 /// Checks if a block is valid returns a blockValidationErrors
-pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors> {
-    let got_block = getBlockFromRaw(blk.hash.clone());
+pub fn check_block(blk: Block) -> std::result::Result<(), BlockValidationErrors> {
+    let got_block = get_block_from_raw(blk.hash.clone());
     if got_block == blk {
         return Ok(());
     } else if got_block == Block::default() {
         if blk.header.network != config().network_id {
-            return Err(blockValidationErrors::networkMissmatch);
+            return Err(BlockValidationErrors::NetworkMissmatch);
         } else if blk.hash != blk.hash_return() {
-            return Err(blockValidationErrors::invalidBlockhash);
+            return Err(BlockValidationErrors::InvalidBlockhash);
         }
-        if getData(config().db_path + "/checkpoints", &blk.hash) != "-1".to_owned() {
+        if get_data(config().db_path + "/checkpoints", &blk.hash) != "-1".to_owned() {
             // we have this block in our checkpoints db and we know the hash is correct and therefore the block is valid
             return Ok(());
         }
@@ -514,15 +510,15 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
             // This is a genesis block (the first block)
             // First we will check if there is a entry for this chain in the genesis blocks db
             let genesis: Block;
-            let mut is_in_db = false;
-            match getGenesisBlock(&blk.header.chain_key) {
+            let is_in_db;
+            match get_genesis_block(&blk.header.chain_key) {
                 Ok(b) => {
                     trace!("found genesis block in db");
                     genesis = b;
                     is_in_db = true;
                 }
                 Err(e) => match e {
-                    genesisBlockErrors::BlockNotFound => {
+                    GenesisBlockErrors::BlockNotFound => {
                         // this block is not in the genesis block db therefor this is a new chain that is not from the swap
                         genesis = Block::default();
                         is_in_db = false;
@@ -532,7 +528,7 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
                             "Failed to get genesis block for chain: {}, gave error: {:?}",
                             &blk.header.chain_key, e
                         );
-                        return Err(blockValidationErrors::failedToGetGenesisBlock);
+                        return Err(BlockValidationErrors::FailedToGetGenesisBlock);
                     }
                 },
             }
@@ -542,7 +538,7 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
                     genesis,
                     blk
                 );
-                return Err(blockValidationErrors::genesisBlockMissmatch);
+                return Err(BlockValidationErrors::GenesisBlockMissmatch);
             } else {
                 if is_in_db == true {
                     // if it is in the db it is guarenteed to be valid, we do not need to validate the block
@@ -550,29 +546,29 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
                 } else {
                     // if it isn't it needs to be validated like any other block
                     if &blk.header.prev_hash != "00000000000" {
-                        return Err(blockValidationErrors::invalidPreviousBlockhash);
-                    } else if let Ok(acc) = getAccount(&blk.header.chain_key) {
+                        return Err(BlockValidationErrors::InvalidPreviousBlockhash);
+                    } else if let Ok(acc) = get_account(&blk.header.chain_key) {
                         // this account already exists, you can't have two genesis blocks
                         trace!("Already got acccount: {:?}", acc);
-                        return Err(blockValidationErrors::genesisBlockMissmatch);
-                    } else if !blk.validSignature() {
-                        return Err(blockValidationErrors::badSignature);
-                    } else if getBlockFromRaw(blk.hash.clone()) != Block::default() {
-                        return Err(blockValidationErrors::blockExists);
+                        return Err(BlockValidationErrors::GenesisBlockMissmatch);
+                    } else if !blk.valid_signature() {
+                        return Err(BlockValidationErrors::BadSignature);
+                    } else if get_block_from_raw(blk.hash.clone()) != Block::default() {
+                        return Err(BlockValidationErrors::BlockExists);
                     } else if blk.header.height != 0
-                        && blk.header.timestamp - (config().transactionTimestampMaxOffset as u64)
+                        && blk.header.timestamp - (config().transaction_timestamp_max_offset as u64)
                             > (SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
                                 .expect("Time went backwards")
                                 .as_millis() as u64)
                     {
-                        return Err(blockValidationErrors::timestampInvalid);
+                        return Err(BlockValidationErrors::TimestampInvalid);
                     } else if blk.header.height != 0
-                        && getBlockFromRaw(blk.header.prev_hash).header.timestamp
+                        && get_block_from_raw(blk.header.prev_hash).header.timestamp
                             > blk.header.timestamp
                     {
                         debug!("Block: {} timestamp under previous timestamp", blk.hash);
-                        return Err(blockValidationErrors::timestampInvalid);
+                        return Err(BlockValidationErrors::TimestampInvalid);
                     }
                     return Ok(());
                 }
@@ -582,29 +578,29 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
             if blk.confimed == true
                 && blk.node_signatures.len() < (2 / 3 * config().commitee_size) as usize
             {
-                return Err(blockValidationErrors::tooLittleSignatures);
+                return Err(BlockValidationErrors::TooLittleSignatures);
             } else {
                 for signature in blk.clone().node_signatures {
                     if !signature.valid() {
-                        return Err(blockValidationErrors::badNodeSignature);
+                        return Err(BlockValidationErrors::BadNodeSignature);
                     }
                 }
             }
-            let prev_blk_hash = getBlock(&blk.header.chain_key, &blk.header.height - 1).hash;
+            let prev_blk_hash = get_block(&blk.header.chain_key, &blk.header.height - 1).hash;
             if blk.header.prev_hash != prev_blk_hash && blk.header.prev_hash != "".to_owned() {
                 debug!(
                     "Expected prev hash to be: {}, got: {}. For block at height: {}",
                     prev_blk_hash, blk.header.prev_hash, blk.header.height
                 );
-                return Err(blockValidationErrors::invalidPreviousBlockhash);
-            } else if let Err(_) = getAccount(&blk.header.chain_key) {
+                return Err(BlockValidationErrors::InvalidPreviousBlockhash);
+            } else if let Err(_) = get_account(&blk.header.chain_key) {
                 // this account doesn't exist, the first block must be a genesis block
                 if blk.header.height != 0 {
-                    return Err(blockValidationErrors::other);
+                    return Err(BlockValidationErrors::Other);
                 }
-            } else if !blk.validSignature() {
-                return Err(blockValidationErrors::badSignature);
-            } else if blk.header.timestamp - (config().transactionTimestampMaxOffset as u64)
+            } else if !blk.valid_signature() {
+                return Err(BlockValidationErrors::BadSignature);
+            } else if blk.header.timestamp - (config().transaction_timestamp_max_offset as u64)
                 > (SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("Time went backwards")
@@ -613,20 +609,20 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
                 debug!("Block: {} too far in futre. Our time: {}, block time: {}, block justifyed time: {}. Delta {}", blk.hash, (SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
-            .as_millis() as u64), blk.header.timestamp, blk.header.timestamp - (config().transactionTimestampMaxOffset as u64),
+            .as_millis() as u64), blk.header.timestamp, blk.header.timestamp - (config().transaction_timestamp_max_offset as u64),
             blk.header.timestamp - (SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
         .as_millis() as u64),);
-                return Err(blockValidationErrors::timestampInvalid);
+                return Err(BlockValidationErrors::TimestampInvalid);
             } else if blk.header.height != 0
-                && getBlockFromRaw(blk.header.prev_hash).header.timestamp > blk.header.timestamp
+                && get_block_from_raw(blk.header.prev_hash).header.timestamp > blk.header.timestamp
             {
-                return Err(blockValidationErrors::timestampInvalid);
+                return Err(BlockValidationErrors::TimestampInvalid);
             }
             for txn in blk.txns {
                 if let Err(e) = txn.valid() {
-                    return Err(blockValidationErrors::invalidTransaction(e));
+                    return Err(BlockValidationErrors::InvalidTransaction(e));
                 } else {
                     return Ok(());
                 }
@@ -634,7 +630,7 @@ pub fn check_block(blk: Block) -> std::result::Result<(), blockValidationErrors>
             return Ok(());
         }
     } else {
-        return Err(blockValidationErrors::blockExists);
+        return Err(BlockValidationErrors::BlockExists);
     }
 }
 
@@ -644,21 +640,26 @@ mod tests {
     use crate::rand::Rng;
     use crate::*;
     use avrio_config::*;
+    use ring::rand as randc;
+    use ring::signature::KeyPair;
     extern crate simple_logger;
-    pub struct item {
+    pub struct Item {
         pub cont: String,
     }
-    impl Hashable for item {
+    impl Hashable for Item {
         fn bytes(&self) -> Vec<u8> {
             self.cont.as_bytes().to_vec()
         }
     }
     pub fn hash(subject: String) -> String {
-        return item { cont: subject }.hash_item();
+        return Item { cont: subject }.hash_item();
     }
     #[test]
     fn test_block() {
-        simple_logger::init_with_level(log::Level::Info).unwrap();
+        simple_logger::SimpleLogger::new()
+            .with_level(log::LevelFilter::Info)
+            .init()
+            .unwrap();
         let mut i_t: u64 = 0;
         let mut rng = rand::thread_rng();
         let rngc = randc::SystemRandom::new();
@@ -704,15 +705,15 @@ mod tests {
             block.signature = bs58::encode(key_pair.sign(msg)).into_string();
             block.header.chain_key = bs58::encode(peer_public_key_bytes).into_string();
             println!("constructed block: {}, checking signature...", block.hash);
-            assert_eq!(block.validSignature(), true);
+            assert_eq!(block.valid_signature(), true);
             let block_clone = block.clone();
             println!("saving block");
             let conf = Config::default();
             let _ = conf.create();
             println!("Block: {:?}", block);
-            saveBlock(block).unwrap();
+            save_block(block).unwrap();
             println!("reading block...");
-            let block_read = getBlockFromRaw(block_clone.hash.clone());
+            let block_read = get_block_from_raw(block_clone.hash.clone());
             println!("read block: {}", block_read.hash);
             assert_eq!(block_read, block_clone);
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -5,8 +5,8 @@ use std::io;
 use std::io::prelude::*;
 extern crate log;
 use dirs::*;
-use rand::prelude::*;
-use sha2::{Digest, Sha256, Sha512};
+
+use sha2::{Digest, Sha256};
 #[macro_use]
 extern crate lazy_static;
 extern crate hex;
@@ -32,9 +32,9 @@ pub struct NetworkConfig {
     pub max_reward: u32,
     pub min_vote: u8,
     pub probatory_epoch_count: u8,
-    pub certificateDifficulty: u128,
+    pub certificate_difficulty: u128,
     pub fullnode_lock_amount: u64,
-    pub transactionTimestampMaxOffset: u32,
+    pub transaction_timestamp_max_offset: u32,
     pub max_time_to_live: u64,
     pub target_epoch_length: u64,
     pub fullnode_lock_time: u64,
@@ -98,9 +98,9 @@ pub struct Config {
     pub max_reward: u32,
     pub min_vote: u8,
     pub probatory_epoch_count: u8,
-    pub certificateDifficulty: u128,
+    pub certificate_difficulty: u128,
     pub fullnode_lock_amount: u64,
-    pub transactionTimestampMaxOffset: u32,
+    pub transaction_timestamp_max_offset: u32,
     pub max_time_to_live: u64,
     pub target_epoch_length: u64,
     pub username_burn_amount: u64,
@@ -233,7 +233,7 @@ impl ConfigSave {
             version_minor: nconf.version_minor,
             coin_name: nconf.coin_name,
             node_drop_off_threshold: nconf.node_drop_off_threshold,
-            certificateDifficulty: nconf.certificateDifficulty,
+            certificate_difficulty: nconf.certificate_difficulty,
             decimal_places: nconf.decimal_places,
             min_intrest: nconf.min_intrest,
             min_vote: nconf.min_vote,
@@ -243,7 +243,7 @@ impl ConfigSave {
             max_reward: nconf.max_reward,
             probatory_epoch_count: nconf.probatory_epoch_count,
             fullnode_lock_amount: nconf.fullnode_lock_amount,
-            transactionTimestampMaxOffset: nconf.transactionTimestampMaxOffset,
+            transaction_timestamp_max_offset: nconf.transaction_timestamp_max_offset,
             max_time_to_live: nconf.max_time_to_live,
             target_epoch_length: nconf.target_epoch_length,
             username_burn_amount: nconf.username_burn_amount,
@@ -284,13 +284,13 @@ impl Default for NetworkConfig {
             max_reward: 25000, // 2.5000 AIO
             min_vote: 65,
             probatory_epoch_count: 10,
-            certificateDifficulty: 1000, // TODO find this value
+            certificate_difficulty: 1000, // TODO find this value
             fullnode_lock_amount: 50000,
-            transactionTimestampMaxOffset: 600000, // 10 mins
-            max_time_to_live: 600000,              // millisecconds
-            target_epoch_length: 18000000,         // 5 Hours
-            fullnode_lock_time: 30 * 5,            // epoches (30 days)
-            username_burn_amount: 5000,            // 0.5000 AIO
+            transaction_timestamp_max_offset: 600000, // 10 mins
+            max_time_to_live: 600000,                 // millisecconds
+            target_epoch_length: 18000000,            // 5 Hours
+            fullnode_lock_time: 30 * 5,               // epoches (30 days)
+            username_burn_amount: 5000,               // 0.5000 AIO
             first_block_hash: "0x...".to_string(),
             commitee_size: 15,
             consensus_commitee_size: 21,

--- a/core/src/account.rs
+++ b/core/src/account.rs
@@ -1,8 +1,9 @@
 extern crate avrio_database;
-use avrio_database::{getData, saveData};
+
 use serde::{Deserialize, Serialize};
 extern crate avrio_config;
 use avrio_config::config;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::prelude::*;
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
@@ -39,7 +40,7 @@ impl Account {
         return Ok(to_dec(self.balance));
     }
     pub fn save(&self) -> Result<(), ()> {
-        match setAccount(self) {
+        match set_account(self) {
             0 => {
                 return Err(());
             }
@@ -51,10 +52,10 @@ impl Account {
             }
         };
     }
-    pub fn new(publicKey: String) -> Account {
+    pub fn new(public_key: String) -> Account {
         // allows Account::new(publicKey)
         let acc: Account = Account {
-            public_key: publicKey,
+            public_key: public_key,
             username: "".to_string(),
             balance: 0,
             locked: 0,
@@ -67,15 +68,15 @@ impl Account {
         };
         return acc;
     }
-    pub fn addUsername(&mut self, userName: String) -> Result<(), ()> {
-        self.username = userName;
+    pub fn add_username(&mut self, user_name: String) -> Result<(), ()> {
+        self.username = user_name;
         self.save()
     }
-    pub fn addAccessCode(&mut self, permCode: &String, pubKey: &String) -> Result<(), ()> {
+    pub fn add_access_code(&mut self, perm_code: &String, pub_key: &String) -> Result<(), ()> {
         let new_acc_key: Accesskey = Accesskey {
-            key: pubKey.to_owned(),
+            key: pub_key.to_owned(),
             allowance: 0,
-            code: permCode.to_owned(),
+            code: perm_code.to_owned(),
         };
         self.access_keys.push(new_acc_key);
         self.save()
@@ -83,23 +84,23 @@ impl Account {
 }
 /// Gets the account assosiated with the username provided
 /// if the account or the username does not exist it returns an err
-pub fn getByUsername(username: &String) -> Result<Account, String> {
+pub fn get_by_username(username: &String) -> Result<Account, String> {
     let path =
         config().db_path + &"/usernames/".to_owned() + &avrio_crypto::raw_hash(username) + ".uname";
     if let Ok(mut file) = File::open(path) {
         let mut contents = String::new();
         let _ = file.read_to_string(&mut contents);
-        return Ok(getAccount(&contents).unwrap_or_default());
+        return Ok(get_account(&contents).unwrap_or_default());
     } else {
         return Err("failed to open file".to_owned());
     }
 }
 
-pub fn setAccount(acc: &Account) -> u8 {
+pub fn set_account(acc: &Account) -> u8 {
     let path = config().db_path + "/accounts/" + &acc.public_key + ".account";
     let serialized: String;
-    let getAccOld = getAccount(&acc.public_key);
-    if let Ok(deserialized) = getAccOld {
+    let get_acc_old = get_account(&acc.public_key);
+    if let Ok(deserialized) = get_acc_old {
         if acc.username != deserialized.username && deserialized != Account::default() {
             let upath = config().db_path
                 + &"/usernames/".to_owned()
@@ -143,7 +144,7 @@ pub fn setAccount(acc: &Account) -> u8 {
 }
 /// Gets the account assosiated with the public_key provided
 /// if the account does not exist it returns an err
-pub fn getAccount(public_key: &String) -> Result<Account, u8> {
+pub fn get_account(public_key: &String) -> Result<Account, u8> {
     let path = config().db_path + &"/accounts/".to_owned() + &public_key + ".account";
     if let Ok(mut file) = File::open(path) {
         let mut contents = String::new();
@@ -159,26 +160,26 @@ pub fn getAccount(public_key: &String) -> Result<Account, u8> {
 }
 
 pub fn open_or_create(public_key: &String) -> Account {
-    if let Ok(acc) = getAccount(public_key) {
+    if let Ok(acc) = get_account(public_key) {
         return acc;
     } else {
-        if let Ok(acc) = getByUsername(public_key) {
+        if let Ok(acc) = get_by_username(public_key) {
             return acc;
         } else {
             let acc = Account::new(public_key.clone());
-            let _ = setAccount(&acc);
+            let _ = set_account(&acc);
             return acc;
         }
     }
 }
 
-pub fn deltaFunds(
+pub fn delta_funds(
     public_key: &String,
     amount: u64,
     mode: u8,
     access_key: String,
 ) -> Result<(), String> {
-    let mut acc: Account = getAccount(public_key).unwrap_or_else(|e| {
+    let mut acc: Account = get_account(public_key).unwrap_or_else(|e| {
         debug!(
             "failed to get account with public key {}, gave error {}",
             public_key, e
@@ -203,7 +204,7 @@ pub fn deltaFunds(
                 );
             } else {
                 acc.balance = acc.balance - amount;
-                return match setAccount(&acc) {
+                return match set_account(&acc) {
                     1 => Ok(()),
                     _ => Err("failed to set account".to_string()),
                 };
@@ -222,7 +223,7 @@ pub fn deltaFunds(
                 warn!("changing funds for account {} with access key {}. Access key does not exist in context to account !", acc.public_key, access_key);
                 return Err("Access Key Does not exist".to_string());
             } else {
-                let after_change = acc.access_keys[i].allowance - amount;
+                let after_change: i64 = (acc.access_keys[i].allowance - amount).try_into().unwrap();
                 if after_change < 0 {
                     // can access key allowance cover this?
                     warn!("changing funds for account {} with access key {:?} would produce negative allowance!",acc.public_key, access_key);
@@ -230,7 +231,7 @@ pub fn deltaFunds(
                 } else {
                     acc.balance = acc.balance - amount;
                     acc.access_keys[i].allowance = acc.access_keys[i].allowance - amount;
-                    return match setAccount(&acc) {
+                    return match set_account(&acc) {
                         1 => Ok(()),
                         _ => Err("Failed to save account".to_string()),
                     };
@@ -242,7 +243,7 @@ pub fn deltaFunds(
         if access_key == "" {
             // none provdied/ using main key
             acc.balance = acc.balance + amount;
-            return match setAccount(&acc) {
+            return match set_account(&acc) {
                 1 => Ok(()),
                 _ => Err("Failed to save account".to_string()),
             };
@@ -261,7 +262,7 @@ pub fn deltaFunds(
             } else {
                 acc.access_keys[i].allowance = acc.access_keys[i].allowance + amount;
                 acc.balance = acc.balance + amount;
-                return match setAccount(&acc) {
+                return match set_account(&acc) {
                     1 => Ok(()),
                     _ => Err("Failed to save account".to_string()),
                 };

--- a/core/src/invite.rs
+++ b/core/src/invite.rs
@@ -8,7 +8,7 @@ use ring::{
 extern crate bs58;
 
 extern crate avrio_database;
-use avrio_database::{getData, saveData};
+use avrio_database::{get_data, save_data};
 
 extern crate avrio_config;
 use avrio_config::config;
@@ -32,7 +32,7 @@ pub fn generate_invite() -> (String, String) {
 
 /// Returns true if the invite is in existance and not spent.
 pub fn unspent(invite: &String) -> bool {
-    if getData(config().db_path + &"/invites".to_owned(), invite) != "u".to_owned() {
+    if get_data(config().db_path + &"/invites".to_owned(), invite) != "u".to_owned() {
         return false;
     } else {
         return true;
@@ -41,7 +41,7 @@ pub fn unspent(invite: &String) -> bool {
 
 /// Returns true if the invite is in existance and not spent.
 pub fn is_spent(invite: &String) -> bool {
-    if getData(config().db_path + &"/invites".to_owned(), invite) != "s".to_owned() {
+    if get_data(config().db_path + &"/invites".to_owned(), invite) != "s".to_owned() {
         return false;
     } else {
         return true;
@@ -52,7 +52,7 @@ pub fn is_spent(invite: &String) -> bool {
 pub fn mark_spent(invite: &String) -> Result<(), ()> {
     if !unspent(invite) {
         return Err(());
-    } else if saveData(
+    } else if save_data(
         "s".to_owned(),
         config().db_path + &"/invites".to_owned(),
         invite.to_owned(),
@@ -66,9 +66,9 @@ pub fn mark_spent(invite: &String) -> Result<(), ()> {
 
 /// Saves the public key into our innvites db (and sets to unspent)
 pub fn new(invite: &String) -> Result<(), ()> {
-    if getData(config().db_path + &"/invites".to_owned(), invite) != "-1".to_owned() {
+    if get_data(config().db_path + &"/invites".to_owned(), invite) != "-1".to_owned() {
         return Err(());
-    } else if saveData(
+    } else if save_data(
         "u".to_owned(),
         config().db_path + &"/invites".to_owned(),
         invite.to_owned(),

--- a/core/src/username.rs
+++ b/core/src/username.rs
@@ -4,7 +4,7 @@ This file handles the registartion and validation of txns.
 */
 
 use avrio_crypto::Hashable;
-use ring::signature::{self, KeyPair};
+use ring::signature::{self};
 use serde::{Deserialize, Serialize};
 extern crate bs58;
 #[derive(Debug, Default, PartialEq, PartialOrd, Ord, Eq, Deserialize, Serialize)]

--- a/core/src/votes.rs
+++ b/core/src/votes.rs
@@ -7,10 +7,7 @@ use avrio_crypto::Hashable;
 extern crate bs58;
 use std::time::Instant;
 extern crate hex;
-use ring::{
-    rand as randc,
-    signature::{self, KeyPair},
-};
+use ring::signature::{self};
 use std::error::Error;
 extern crate avrio_config;
 use avrio_config::config;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -20,7 +20,6 @@ use ring::{
 
 // avrio config, for getting the address prefix
 extern crate avrio_config;
-use avrio_config::config;
 
 pub struct Keypair {
     pub public_key: Publickey,

--- a/id/src/lib.rs
+++ b/id/src/lib.rs
@@ -7,10 +7,7 @@ extern crate rand;
 #[macro_use]
 extern crate log;
 use avrio_crypto::raw_hash;
-use ring::{
-    rand as randc,
-    signature::{self, KeyPair},
-};
+use ring::signature;
 use serde::{Deserialize, Serialize};
 pub struct HashParams {
     pub iterations: u32,
@@ -34,8 +31,8 @@ pub fn check_difficulty(hash: &String, difficulty: u128) -> bool {
     difficulty > difficulty_bytes_as_u128(&hash.as_bytes().to_vec())
 }
 
-fn calculate_hash_params(PrevBlockHash: String) -> HashParams {
-    let cu = PrevBlockHash.as_bytes();
+fn _calculate_hash_params(prev_block_hash: String) -> HashParams {
+    let cu = prev_block_hash.as_bytes();
     let b: Vec<u8> = cu.iter().cloned().collect();
     let mut a: u32 = 0;
     let _i = 0;
@@ -57,7 +54,7 @@ fn hash_string(params: &HashParams, s: &String) -> String {
     return out;
 }
 
-pub fn generateId(
+pub fn generate_id(
     k: String,
     public_key: String,
     private_key: String,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -7,14 +7,13 @@ rpc/lib.rs -
 #![feature(proc_macro_hygiene, decl_macro)]
 
 extern crate avrio_core;
-use avrio_blockchain::{check_block, enact_block, getBlockFromRaw, saveBlock, Block};
-use avrio_core::account::{getAccount, Account};
+use avrio_blockchain::get_block_from_raw;
+use avrio_core::account::{get_account, Account};
 #[macro_use]
 extern crate rocket;
 use rocket::config::{Config, Environment, LoggingLevel};
 
 extern crate avrio_p2p;
-use avrio_p2p::prop_block;
 
 fn not_supported() -> String {
     "{ \"error\": \"this method is not yet supported\"}".to_owned()
@@ -26,7 +25,7 @@ fn must_provide_method() -> &'static str {
 
 #[get("/getBalance/<chain>")]
 fn get_balance(chain: String) -> String {
-    let acc: Account = getAccount(&chain).unwrap_or(Account::default());
+    let acc: Account = get_account(&chain).unwrap_or(Account::default());
     let balance: u64 = acc.balance;
     let locked: u64 = acc.locked;
     "{    \"response\": 200, \"chainkey\": ".to_owned()
@@ -40,7 +39,7 @@ fn get_balance(chain: String) -> String {
 
 #[get("/getBlock/<hash>")]
 fn get_block(hash: String) -> String {
-    let blk = getBlockFromRaw(hash);
+    let blk = get_block_from_raw(hash);
     serde_json::to_string(&blk).unwrap_or_default()
 }
 
@@ -48,8 +47,8 @@ fn get_block(hash: String) -> String {
 fn get_usernames() -> String {
     not_supported()
 }
-#[post("/submit_block", format = "application/json", data = "<block_dat>")]
-fn submit_block(block_dat: rocket::Data) -> String {
+#[post("/submit_block", format = "application/json", data = "<_block_dat>")]
+fn submit_block(_block_dat: rocket::Data) -> String {
     /* TODO: Find a way of getting all conections currently active (a function) wich returns a vec of refrences to mutable TcpStreams so we can prop the block
     let block_utf8 = block_dat.peek();
     let block: String = String::from_utf8(block_utf8.to_vec()).unwrap_or_default();


### PR DESCRIPTION
Every warning emitted by the compiler was squelched. Most were just naming convention issues, shadowed variables, a couple of unused results and unused imports.

Also updated calls to simple_logger to no longer used the deprecated API.

Project does compile.

See issue [#17](https://github.com/avrio-project/avrio-rs/issues/17)